### PR TITLE
refactor: IC-166 fetch coordinator email from active event edition

### DIFF
--- a/backend/src/committee-member/committee-member.module.ts
+++ b/backend/src/committee-member/committee-member.module.ts
@@ -5,5 +5,6 @@ import { CommitteeMemberController } from './committee-member.controller';
 @Module({
   controllers: [CommitteeMemberController],
   providers: [CommitteeMemberService],
+  exports: [CommitteeMemberService],
 })
 export class CommitteeMemberModule {}

--- a/backend/src/committee-member/committee-member.service.ts
+++ b/backend/src/committee-member/committee-member.service.ts
@@ -85,6 +85,27 @@ export class CommitteeMemberService {
     });
   }
 
+  async findCurrentCoordinator(eventEditionId: string) {
+    const coordinator = await this.prismaClient.committeeMember.findFirst({
+      where: {
+        eventEditionId,
+        level: CommitteeLevel.Coordinator,
+      },
+      include: { user: true },
+    });
+
+    if (!coordinator) {
+      throw new NotFoundException('Coordenador não encontrado');
+    }
+
+    const { user, ...responseCommitteeMember } = coordinator;
+    return new ResponseCommitteeMemberDto({
+      ...responseCommitteeMember,
+      userName: user.name,
+      userEmail: user.email,
+    });
+  }
+
   async findAll(eventEditionId: string) {
     // To create the ResponseCommitteeMemberDto, we need to also return the user name
     const found = await this.prismaClient.committeeMember.findMany({

--- a/backend/src/committee-member/dto/response-committee-member.dto.ts
+++ b/backend/src/committee-member/dto/response-committee-member.dto.ts
@@ -16,6 +16,9 @@ export class ResponseCommitteeMemberDto {
   userName: string;
 
   @Expose()
+  userEmail: string;
+
+  @Expose()
   level: CommitteeLevel;
 
   @Expose()

--- a/backend/src/event-edition/event-edition.module.ts
+++ b/backend/src/event-edition/event-edition.module.ts
@@ -5,5 +5,6 @@ import { EventEditionService } from './event-edition.service';
 @Module({
   controllers: [EventEditionController],
   providers: [EventEditionService],
+  exports: [EventEditionService],
 })
 export class EventEditionModule {}

--- a/backend/src/event-edition/event-edition.service.ts
+++ b/backend/src/event-edition/event-edition.service.ts
@@ -79,6 +79,22 @@ export class EventEditionService {
     return eventResponseDto;
   }
 
+  async findActive() {
+    const event = await this.prismaClient.eventEdition.findFirst({
+      where: {
+        isActive: true,
+      },
+    });
+
+    if (!event) {
+      throw new BadRequestException('Não existe nenhum evento ativo');
+    }
+
+    const eventResponseDto = new EventEditionResponseDto(event);
+
+    return eventResponseDto;
+  }
+
   async update(id: string, updateEventEdition: UpdateEventEditionDto) {
     const event = await this.prismaClient.eventEdition.findUnique({
       where: {

--- a/backend/src/mailing/mailing.module.ts
+++ b/backend/src/mailing/mailing.module.ts
@@ -3,6 +3,8 @@ import { MailingService } from './mailing.service';
 import { MailingController } from './mailing.controller';
 import { ClientsModule, Transport } from '@nestjs/microservices';
 import { queueConstants } from '../queue/constants';
+import { EventEditionModule } from 'src/event-edition/event-edition.module';
+import { CommitteeMemberModule } from 'src/committee-member/committee-member.module';
 
 @Module({
   imports: [
@@ -41,6 +43,8 @@ import { queueConstants } from '../queue/constants';
         },
       },
     ]),
+    EventEditionModule,
+    CommitteeMemberModule,
   ],
   controllers: [MailingController],
   providers: [MailingService],

--- a/backend/src/mailing/mailing.service.spec.ts
+++ b/backend/src/mailing/mailing.service.spec.ts
@@ -1,5 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { MailingService } from './mailing.service';
+import { EventEditionService } from '../event-edition/event-edition.service';
+import { CommitteeMemberService } from '../committee-member/committee-member.service';
+import { PrismaService } from '../prisma/prisma.service';
 
 describe('ContactService', () => {
   let service: MailingService;
@@ -16,9 +19,16 @@ describe('ContactService', () => {
     };
 
     const module: TestingModule = await Test.createTestingModule({
-      providers: [MailingService,
+      providers: [
+        MailingService,
+        EventEditionService,
+        CommitteeMemberService,
+        PrismaService,
         { provide: 'EMAIL_ERROR_SERVICE', useValue: mockEmailErrorService },
-        { provide: 'EMAIL_SERVER_LIMIT_SERVICE', useValue: mockEmailServerLimitService },
+        {
+          provide: 'EMAIL_SERVER_LIMIT_SERVICE',
+          useValue: mockEmailServerLimitService,
+        },
         { provide: 'DEAD_QUEUE_SERVICE', useValue: mockDeadQueueService },
       ],
     }).compile();


### PR DESCRIPTION
Refactor contact functionality to dynamically retrieve the coordinator's email from the active event edition instead of using the ORGANIZER_EMAIL environment variable. This improves email accuracy and removes dependency on outdated environment variables.