### PR TITLE
IC-260 Corrigir Duplicação de Membros da Comissão

### DIFF
--- a/backend/src/event-edition/event-edition.service.ts
+++ b/backend/src/event-edition/event-edition.service.ts
@@ -215,20 +215,31 @@ export class EventEditionService {
   ) {
     await Promise.all(
       ids.map(async (id) => {
-        const committeeMember = await this.prismaClient.committeeMember.create({
-          data: {
-            eventEditionId: eventEditionId,
-            userId: id,
-            level: CommitteeLevel.Committee,
-            role,
-          },
-        });
-
-        if (committeeMember) {
-          await this.updateUserLevel(id, committeeMember.level);
-        }
+          const existingMember = await this.prismaClient.committeeMember.findUnique({
+              where: {
+                  eventEditionId_userId: {
+                      eventEditionId: eventEditionId,
+                      userId: id,
+                  },
+              },
+          });
+  
+          if (!existingMember) {
+              const committeeMember = await this.prismaClient.committeeMember.create({
+                  data: {
+                      eventEditionId: eventEditionId,
+                      userId: id,
+                      level: CommitteeLevel.Committee,
+                      role,
+                  },
+              });
+  
+              if (committeeMember) {
+                  await this.updateUserLevel(id, committeeMember.level);
+              }
+          }
       }),
-    );
+  );  
   }
 
   private async updateUserLevel(


### PR DESCRIPTION
Resolve a [issue #309](https://github.com/luizcdc/portalwepgcomp/issues/309).

### **Descrição:**
Conforme alinhado com @luizcdc, foi identificado que um usuário não pode ocupar mais de um cargo na comissão organizadora de um evento. Para resolver esse problema, foi adicionado o método `validateUniqueCommitteeMembers`, que valida previamente se algum usuário está alocado em múltiplos cargos antes da criação do evento.

No fluxo anterior, o evento era criado primeiro, e somente depois os usuários eram associados ao evento com seus respectivos cargos. Isso causava problemas quando um mesmo usuário era atribuído a mais de um cargo, como descrito na issue. Por exemplo:
- O **Usuário A** era registrado como "Comissão Organizadora".
- No entanto, se o mesmo usuário também fosse selecionado como "Apoio TI", ao tentar inseri-lo no banco, ocorria uma violação da restrição de unicidade, pois o usuário já estava relacionado ao evento.

Com a introdução do método `validateUniqueCommitteeMembers`, essa validação agora é feita antes de criar o evento. O método verifica se há usuários duplicados entre as funções atribuídas, considerando também o usuário responsável por criar a edição do evento.

Além disso, uma segunda validação foi implementada no método `createCommitteeMembersFromArray` para garantir a unicidade nos campos `eventEditionId` e `userId`. Essa validação atua como uma camada de segurança adicional, evitando violações de restrição única no banco de dados, mesmo em cenários extremos. Com isso, membros duplicados da comissão não são criados durante o envio do formulário de edição de eventos.

Por fim, foram adicionados testes para cobrir o novo método e validar o fluxo atualizado.

---

### **Possíveis melhorias no frontend:**
1. Seria ideal que usuários já atribuídos a uma função não aparecessem disponíveis nas demais opções do formulário. Isso ajudaria a evitar erros de seleção no backend. No entanto, como a associação ocorre apenas ao clicar em "Criar Nova Edição", essa alteração exigiria revisão do fluxo de frontend.
2. Após excluir um evento, a página atualmente não reflete a exclusão imediatamente. Seria interessante implementar uma recarga automática ou atualização da lista para corrigir isso e melhorar a experiência do usuário.