### PR TITLE
feat: IC-278 Implementing route to set user level as default

### DIFF
--- a/backend/src/user/user.controller.spec.ts
+++ b/backend/src/user/user.controller.spec.ts
@@ -21,6 +21,7 @@ describe('UserController', () => {
           provide: UserService,
           useValue: {
             create: jest.fn(),
+            setDefault: jest.fn(),
             setAdmin: jest.fn(),
             setSuperAdmin: jest.fn(),
             remove: jest.fn(),
@@ -72,6 +73,37 @@ describe('UserController', () => {
 
       expect(userService.create).toHaveBeenCalledWith(createUserDto);
       expect(result).toEqual(userResponse);
+    });
+  });
+
+  describe('set-default', () => {
+    it('should set an user as default and return the result', async () => {
+      const setDefaultDto: SetAdminDto = {
+        requestUserId: 'c73c2c5a-b6ee-4d8e-a47a-5c159728f2ea',
+        targetUserId: '6047cb57-db11-4dc4-a305-33b86723dd09',
+      };
+
+      const setDefaultResponse = {
+        id: '1',
+        name: 'John Doe',
+        email: 'johndoe@example.com',
+        photoFilePath: 'user-photo-url',
+        profile: Profile.Professor,
+        level: UserLevel.Default,
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        isVerified: false,
+      };
+
+      jest
+        .spyOn(userService, 'setDefault')
+        .mockResolvedValue(setDefaultResponse);
+
+      const result = await controller.setDefault(setDefaultDto);
+
+      expect(userService.setDefault).toHaveBeenCalledWith(setDefaultDto);
+      expect(result).toEqual(setDefaultResponse);
     });
   });
 

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -31,6 +31,13 @@ export class UserController {
     return await this.userService.create(createUserDto);
   }
 
+  @Post('set-default')
+  @UserLevels(UserLevel.Superadmin, UserLevel.Admin)
+  @ApiBearerAuth()
+  async setDefault(@Body() setDefaultDto: SetAdminDto) {
+    return await this.userService.setDefault(setDefaultDto);
+  }
+
   @Post('set-admin')
   @UserLevels(UserLevel.Superadmin, UserLevel.Admin)
   @ApiBearerAuth()


### PR DESCRIPTION
Coverage:

user.service
![image](https://github.com/user-attachments/assets/16a7d5e8-d38c-43d1-bee4-4b8aec04bb7c)
![image](https://github.com/user-attachments/assets/684d6463-559c-43a9-9685-41cc4182cb76)

user.controller
![image](https://github.com/user-attachments/assets/28a2a4ed-e1f2-44b8-b9e3-3859fc2f6e16)
![image](https://github.com/user-attachments/assets/9ea42865-c456-41f9-b148-9b5fc9514e35)
