### PR TITLE
IC-277 - Cadastrar Professores do PGCOMP com script 

### DIFF
--- a/backend/src/user/dto/create-user.dto.ts
+++ b/backend/src/user/dto/create-user.dto.ts
@@ -53,6 +53,10 @@ export class CreateUserDto {
   @IsOptional()
   @IsBoolean()
   isActive?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  isVerified?: boolean;
 }
 
 export class SetAdminDto {

--- a/backend/src/user/user.service.spec.ts
+++ b/backend/src/user/user.service.spec.ts
@@ -167,6 +167,7 @@ describe('UserService', () => {
           ...createUserDto,
           password: hashedPassword,
           level: 'Default',
+          isActive: true,
         },
       });
       expect(result).toBeInstanceOf(ResponseUserDto);
@@ -201,6 +202,7 @@ describe('UserService', () => {
         registrationNumber: '2021001',
         password: 'password123',
         profile: Profile.Professor,
+        isActive: true,
       };
 
       const result = await service.create(createUserDto);
@@ -263,6 +265,7 @@ describe('UserService', () => {
           ...createUserDto,
           password: hashedPassword,
           level: 'Default',
+          isActive: false,
         },
       });
 
@@ -862,114 +865,6 @@ describe('UserService', () => {
     });
   });
 
-  describe('activateProfessor', () => {
-    it('should throw an AppException if user is not found', async () => {
-      prismaService.userAccount.findUnique = jest.fn().mockResolvedValue(null);
-
-      const userId = 'nonexistent-user-id';
-
-      await expect(service.activateProfessor(userId)).rejects.toThrow(
-        new AppException('Usuário não encontrado', 404),
-      );
-
-      expect(prismaService.userAccount.findUnique).toHaveBeenCalledWith({
-        where: { id: userId },
-      });
-    });
-
-    it('should throw an AppException if user is not a professor', async () => {
-      const userMock = {
-        id: '1',
-        name: 'John',
-        email: 'user@example.com',
-        profile: 'Student',
-        isActive: false,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      };
-
-      prismaService.userAccount.findUnique = jest
-        .fn()
-        .mockResolvedValue(userMock);
-
-      const userId = '1';
-
-      await expect(service.activateProfessor(userId)).rejects.toThrow(
-        new AppException('Este usuário não é um professor', 403),
-      );
-
-      expect(prismaService.userAccount.findUnique).toHaveBeenCalledWith({
-        where: { id: userId },
-      });
-    });
-
-    it('should throw an AppException if user is already active', async () => {
-      const userMock = {
-        id: '1',
-        name: 'John',
-        email: 'user@example.com',
-        profile: 'Professor',
-        isActive: true,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      };
-
-      prismaService.userAccount.findUnique = jest
-        .fn()
-        .mockResolvedValue(userMock);
-
-      const userId = '1';
-
-      await expect(service.activateProfessor(userId)).rejects.toThrow(
-        new AppException('O usuário já está ativo', 409),
-      );
-
-      expect(prismaService.userAccount.findUnique).toHaveBeenCalledWith({
-        where: { id: userId },
-      });
-    });
-
-    it('should update the user to active if conditions are met', async () => {
-      const userMock = {
-        id: '1',
-        name: 'John',
-        email: 'user@example.com',
-        profile: 'Professor',
-        isActive: false,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      };
-
-      const updatedUserMock = {
-        ...userMock,
-        isActive: true,
-      };
-
-      prismaService.userAccount.findUnique = jest
-        .fn()
-        .mockResolvedValue(userMock);
-
-      prismaService.userAccount.update = jest
-        .fn()
-        .mockResolvedValue(updatedUserMock);
-
-      const userId = '1';
-
-      const result = await service.activateProfessor(userId);
-
-      expect(prismaService.userAccount.findUnique).toHaveBeenCalledWith({
-        where: { id: userId },
-      });
-
-      expect(prismaService.userAccount.update).toHaveBeenCalledWith({
-        where: { id: userId },
-        data: { isActive: true },
-      });
-
-      expect(result).toEqual(updatedUserMock);
-    });
-  });
-
   describe('findAll', () => {
     it('should return all users when no filters are applied', async () => {
       const usersMock = [
@@ -1290,4 +1185,65 @@ describe('UserService', () => {
       expect(prismaService.userAccount.update).not.toHaveBeenCalled();
     });
   });
+
+  describe('updateRegistrationNumber', () => {
+    it('should update the registration number for an existing user', async () => {
+      const userId = 'user-id-1';
+      const newRegistrationNumber = 'PROF1234';
+  
+      // Mock do Prisma para simular a atualização do registro
+      prismaService.userAccount.update = jest.fn().mockResolvedValue({
+        id: userId,
+        registrationNumber: newRegistrationNumber,
+      });
+  
+      // Chamada do método
+      await service.updateRegistrationNumber(userId, newRegistrationNumber);
+  
+      // Verificando se a função Prisma foi chamada corretamente
+      expect(prismaService.userAccount.update).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: { registrationNumber: newRegistrationNumber },
+      });
+    });
+  });
+  
+  it('should throw an error if user is not found', async () => {
+    const userId = 'nonexistent-user-id';
+    const newRegistrationNumber = 'PROF1234';
+  
+    // Mock do Prisma para simular que o usuário não foi encontrado
+    prismaService.userAccount.update = jest.fn().mockRejectedValue(new Error('User not found'));
+  
+    // Esperando que uma exceção seja lançada
+    await expect(
+      service.updateRegistrationNumber(userId, newRegistrationNumber),
+    ).rejects.toThrowError('User not found');
+  
+    // Verificando se o Prisma foi chamado corretamente
+    expect(prismaService.userAccount.update).toHaveBeenCalledWith({
+      where: { id: userId },
+      data: { registrationNumber: newRegistrationNumber },
+    });
+  });
+
+  it('should update the registration number to null', async () => {
+    const userId = 'user-id-1';
+    const registrationNumber = null; // Registro sendo setado para null
+  
+    // Mock do Prisma para simular a atualização
+    prismaService.userAccount.update = jest.fn().mockResolvedValue({
+      id: userId,
+      registrationNumber,
+    });
+  
+    // Chamada do método
+    await service.updateRegistrationNumber(userId, registrationNumber);
+  
+    // Verificando se a função Prisma foi chamada corretamente
+    expect(prismaService.userAccount.update).toHaveBeenCalledWith({
+      where: { id: userId },
+      data: { registrationNumber },
+    });
+  });  
 });

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -402,4 +402,11 @@ export class UserService {
       throw error;
     }
   }
+
+  async updateRegistrationNumber(userId: string, registrationNumber: string | null): Promise<void> {
+    await this.prismaClient.userAccount.update({
+      where: { id: userId },
+      data: { registrationNumber },
+    });
+  }
 }


### PR DESCRIPTION
Este MR introduz ajustes para permitir a execução do script de cadastro de professores do PGCOMP.

### Alterações Realizadas:
1. **Adicionado `isVerified` como Propriedade Opcional**  
   - O método `create` do `UserService` valida se um e-mail de confirmação deve ser enviado com base no campo `isVerified`. Para evitar essa validação durante o cadastro de professores, o campo `isVerified` foi adicionado como uma propriedade opcional no `CreateUserDto`.

2. **Adicionado Método `updateRegistrationNumber`**  
   - Como o número de matrícula (`registrationNumber`) de um professor não é público, foi criado o método `updateRegistrationNumber` no `UserService`. Esse método permite atualizar o valor do campo após a criação do usuário.

### Fluxo para Cadastro de Professores:
- Durante o cadastro do professor, o campo `isVerified` é passado como `true` para não enviar o e-mail de confirmação.
- Durante o cadastro do professor, o campo `registrationNumber` é preenchido inicialmente com um valor fictício. 
- Após o cadastro, o método `updateRegistrationNumber` é utilizado para alterar o valor para `null`, permitindo que o professor atualize o número posteriormente, caso necessário.